### PR TITLE
doc: update profile for post-EICUG era

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
-This is the GitHub organization for the Electron-Ion Collider (EIC). It provides various resources for software development and usage, including repositories and documentation, and is maintained by the EIC User Group (EICUG) and the EPIC Collaboration.
+This is the GitHub organization for the Electron-Ion Collider (EIC). It provides various resources for software development and usage, including repositories and documentation, and is maintained by the EIC detector collaborations.
 
 ## How to join?
 
-Please contact [eicug-software-conveners@eicug.org](mailto:eicug-software-conveners@eicug.org) from your institutional email address. In your email, please state your GitHub username and whether you or your sponsor/advisor is a member of the EICUG. Either you or your sponsor/advisor needs to be listed in the [EIC User Group Phone Book](https://phonebook.sdcc.bnl.gov/eic/client/).
+Please contact the Software & Computing coordinators of your EIC detector collaboration (e.g. [eic-projdet-compsw-l-owner@lists.bnl.gov](mailto:eic-projdet-compsw-l-owner@lists.bnl.gov) for ePIC) from your institutional email address. In your email, please state your GitHub username and whether you or your sponsor/advisor is a member of the EICUG. Either you or your sponsor/advisor needs to be listed in the [EIC User Group Phone Book](https://phonebook.sdcc.bnl.gov/eic/client/).
 
-This will give you read access to all public repositories. For write access to select repositories, you may request to join various GitHub teams, e.g., [EPIC Devs](https://github.com/orgs/eic/teams/epic-devs). As a member of the GitHub organization, you may contact the [Admins](https://github.com/orgs/eic/teams/admins) team for further questions.
+This will give you read access to all public repositories. For write access to select repositories, you may request to join various GitHub teams, e.g., [ePIC Devs](https://github.com/orgs/eic/teams/epic-devs). As a member of the GitHub organization, you may contact the [Admins](https://github.com/orgs/eic/teams/admins) team for further questions.


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There are no more eicug-software-conveners now that the EICUG has not SWG anymore.