### PR TITLE
fix: update to eic-software-l-request@lists.bnl.gov

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,6 +2,6 @@ This is the GitHub organization for the Electron-Ion Collider (EIC). It provides
 
 ## How to join?
 
-Please contact the Software & Computing coordinators of your EIC detector collaboration (e.g. [eic-projdet-compsw-l-owner@lists.bnl.gov](mailto:eic-projdet-compsw-l-owner@lists.bnl.gov) for ePIC) from your institutional email address. In your email, please state your GitHub username and whether you or your sponsor/advisor is a member of the EICUG. Either you or your sponsor/advisor needs to be listed in the [EIC User Group Phone Book](https://phonebook.sdcc.bnl.gov/eic/client/).
+Please contact the Software & Computing coordinators of your EIC detector collaboration (e.g. [eic-projdet-compsw-l-request@lists.bnl.gov](mailto:eic-projdet-compsw-l-request@lists.bnl.gov) for ePIC) from your institutional email address. In your email, please state your GitHub username and whether you or your sponsor/advisor is a member of the EICUG. Either you or your sponsor/advisor needs to be listed in the [EIC User Group Phone Book](https://phonebook.sdcc.bnl.gov/eic/client/).
 
 This will give you read access to all public repositories. For write access to select repositories, you may request to join various GitHub teams, e.g., [ePIC Devs](https://github.com/orgs/eic/teams/epic-devs). As a member of the GitHub organization, you may contact the [Admins](https://github.com/orgs/eic/teams/admins) team for further questions.


### PR DESCRIPTION
### Briefly, what does this PR introduce?
It's clear BNL won't ever manage to make the old owner email address work.