### PR TITLE
ci: add ePIC Review Board sync workflow

### DIFF
--- a/.github/workflows/sync-epic-review-board.yml
+++ b/.github/workflows/sync-epic-review-board.yml
@@ -1,0 +1,135 @@
+# Syncs the ePIC Review Board (https://github.com/orgs/eic/projects/19)
+# for all eic org repositories.
+#
+# Runs every 15 minutes. Requires an org secret EPIC_REVIEW_BOARD_TOKEN
+# containing a PAT with scopes: project, repo, read:org.
+#
+# What this workflow does:
+#   1. Adds any open PR that has a pending review request from
+#      eic/epic-review-team but is not yet on the board.
+#   2. For every PR already on the board, syncs its column to reflect
+#      the current review state (Needs Review / In Review /
+#      Changes Requested / Approved).
+#   3. Archives items whose PR has been closed or merged.
+
+name: Sync ePIC Review Board
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      EPIC_REVIEW_BOARD_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync PR review status
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.EPIC_REVIEW_BOARD_TOKEN }}
+      PROJECT_NUMBER: "19"
+      PROJECT_ID:     "PVT_kwDOA7zONM4BZPiG"
+      STATUS_FIELD_ID: "PVTSSF_lADOA7zONM4BZPiGzhUPmRk"
+      OPT_NEEDS_REVIEW:       "21cae81d"
+      OPT_IN_REVIEW:          "59df07d6"
+      OPT_CHANGES_REQUESTED:  "2e6a5d80"
+      OPT_APPROVED:           "cf951501"
+
+    steps:
+      # ------------------------------------------------------------------
+      # Step 1 – Add any open PR with an active team review request that
+      #           is not yet on the board.
+      # ------------------------------------------------------------------
+      - name: Add new PRs with pending review requests
+        run: |
+          set -euo pipefail
+
+          mapfile -t URLS < <(
+            gh search prs "org:eic review-requested:eic/epic-review-team is:open" \
+              --json url --limit 100 --jq '.[].url'
+          )
+          echo "Found ${#URLS[@]} open PRs with active team review request"
+
+          for URL in "${URLS[@]}"; do
+            # Skip if already on the board
+            ALREADY=$(gh api graphql -f query='
+              query($u: URI!) {
+                resource(url: $u) {
+                  ... on PullRequest {
+                    projectItems(first: 10) {
+                      nodes { project { number } }
+                    }
+                  }
+                }
+              }' -f u="$URL" \
+              --jq '.data.resource.projectItems.nodes[] | select(.project.number == 19)' \
+              2>/dev/null || true)
+
+            if [ -z "$ALREADY" ]; then
+              echo "  Adding: $URL"
+              gh project item-add "$PROJECT_NUMBER" --owner eic --url "$URL" \
+                --format json > /dev/null
+            fi
+          done
+
+      # ------------------------------------------------------------------
+      # Step 2 – For every PR already on the board: sync its column and
+      #           archive it if the PR has been closed or merged.
+      # ------------------------------------------------------------------
+      - name: Sync status and archive closed PRs
+        run: |
+          set -euo pipefail
+
+          gh project item-list "$PROJECT_NUMBER" --owner eic \
+            --format json --limit 200 \
+            | jq -r '.items[]
+                     | select(.content.type == "PullRequest")
+                     | "\(.id)\t\(.content.url)"' \
+            | while IFS=$'\t' read -r ITEM_ID PR_URL; do
+
+              DATA=$(gh api graphql -f query='
+                query($u: URI!) {
+                  resource(url: $u) {
+                    ... on PullRequest {
+                      state
+                      reviewDecision
+                      latestReviews(first: 10) { nodes { state } }
+                    }
+                  }
+                }' -f u="$PR_URL")
+
+              STATE=$(echo "$DATA"    | jq -r '.data.resource.state')
+              DECISION=$(echo "$DATA" | jq -r '.data.resource.reviewDecision // ""')
+              NREVIEWS=$(echo "$DATA" | jq    '.data.resource.latestReviews.nodes | length')
+
+              # Archive PRs that have been closed or merged
+              if [ "$STATE" != "OPEN" ]; then
+                echo "  Archiving ($STATE): $PR_URL"
+                gh project item-archive "$PROJECT_NUMBER" --owner eic --id "$ITEM_ID"
+                continue
+              fi
+
+              # Map review state to board column
+              if   [ "$DECISION" = "APPROVED" ];          then
+                OPT="$OPT_APPROVED"; LABEL="Approved"
+              elif [ "$DECISION" = "CHANGES_REQUESTED" ]; then
+                OPT="$OPT_CHANGES_REQUESTED"; LABEL="Changes Requested"
+              elif [ "$NREVIEWS" -gt 0 ];                 then
+                OPT="$OPT_IN_REVIEW"; LABEL="In Review"
+              else
+                OPT="$OPT_NEEDS_REVIEW"; LABEL="Needs Review"
+              fi
+
+              echo "  → $LABEL: $PR_URL"
+              gh project item-edit \
+                --id "$ITEM_ID" \
+                --project-id "$PROJECT_ID" \
+                --field-id "$STATUS_FIELD_ID" \
+                --single-select-option-id "$OPT"
+
+            done

--- a/.github/workflows/sync-epic-review-board.yml
+++ b/.github/workflows/sync-epic-review-board.yml
@@ -26,6 +26,12 @@ on:
 permissions:
   contents: read
 
+# Prevent concurrent runs from racing while editing the same project board.
+# Queues a new run rather than cancelling in-progress ones.
+concurrency:
+  group: epic-review-board-sync
+  cancel-in-progress: false
+
 jobs:
   sync:
     name: Sync PR review status
@@ -50,26 +56,37 @@ jobs:
           set -euo pipefail
 
           mapfile -t URLS < <(
-            gh search prs \
-              --owner eic --review-requested eic/epic-review-team --state open \
-              --json url --limit 100 --jq '.[].url'
+            # When triggered by a per-repo real-time event (workflow_call),
+            # scope the search to that repo only to avoid an unnecessary
+            # org-wide scan on every review submission.
+            if [ "${{ github.event_name }}" = "workflow_call" ]; then
+              gh search prs \
+                --repo "${{ github.event.repository.full_name }}" \
+                --review-requested eic/epic-review-team --state open \
+                --json url --limit 1000 --jq '.[].url'
+            else
+              gh search prs \
+                --owner eic --review-requested eic/epic-review-team --state open \
+                --json url --limit 1000 --jq '.[].url'
+            fi
           )
           echo "Found ${#URLS[@]} open PRs with active team review request"
 
           for URL in "${URLS[@]}"; do
-            # Skip if already on the board
+            # Skip if already on the board.
+            # Use PROJECT_NUMBER env var and a generous page size so the
+            # check is not fooled by PRs that belong to many projects.
             ALREADY=$(gh api graphql -f query='
               query($u: URI!) {
                 resource(url: $u) {
                   ... on PullRequest {
-                    projectItems(first: 10) {
+                    projectItems(first: 100) {
                       nodes { project { number } }
                     }
                   }
                 }
               }' -f u="$URL" \
-              --jq '.data.resource.projectItems.nodes[] | select(.project.number == 19)' \
-              2>/dev/null || true)
+              | jq -r ".data.resource.projectItems.nodes[] | select(.project.number == $PROJECT_NUMBER)")
 
             if [ -z "$ALREADY" ]; then
               echo "  Adding: $URL"
@@ -87,7 +104,7 @@ jobs:
           set -euo pipefail
 
           gh project item-list "$PROJECT_NUMBER" --owner eic \
-            --format json --limit 200 \
+            --format json --limit 1200 \
             | jq -r '.items[]
                      | select(.content.type == "PullRequest")
                      | "\(.id)\t\(.content.url)"' \

--- a/.github/workflows/sync-epic-review-board.yml
+++ b/.github/workflows/sync-epic-review-board.yml
@@ -50,7 +50,8 @@ jobs:
           set -euo pipefail
 
           mapfile -t URLS < <(
-            gh search prs "org:eic review-requested:eic/epic-review-team is:open" \
+            gh search prs \
+              --owner eic --review-requested eic/epic-review-team --state open \
               --json url --limit 100 --jq '.[].url'
           )
           echo "Found ${#URLS[@]} open PRs with active team review request"

--- a/workflow-templates/epic-review-board.properties.json
+++ b/workflow-templates/epic-review-board.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "ePIC Review Board – real-time sync",
+  "description": "Trigger an immediate sync to the ePIC Review Board project (https://github.com/orgs/eic/projects/19) whenever a review is requested from eic/epic-review-team, a review is submitted, or a PR is closed.",
+  "iconName": "octicon workflow",
+  "categories": ["ePIC", "code-review", "project-management"]
+}

--- a/workflow-templates/epic-review-board.properties.json
+++ b/workflow-templates/epic-review-board.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "ePIC Review Board – real-time sync",
   "description": "Trigger an immediate sync to the ePIC Review Board project (https://github.com/orgs/eic/projects/19) whenever a review is requested from eic/epic-review-team, a review is submitted, or a PR is closed.",
-  "iconName": "octicon workflow",
+  "iconName": "githubactions",
   "categories": ["ePIC", "code-review", "project-management"]
 }

--- a/workflow-templates/epic-review-board.yml
+++ b/workflow-templates/epic-review-board.yml
@@ -1,0 +1,33 @@
+# Optional starter workflow for individual repos that want real-time
+# (event-driven) column updates in addition to the 15-minute scheduled
+# sync that runs automatically in eic/.github.
+#
+# Usage: copy to .github/workflows/epic-review-board.yml in your repo.
+# Requires the EPIC_REVIEW_BOARD_TOKEN org secret (scopes: project, repo,
+# read:org).  No other configuration is needed.
+
+name: ePIC Review Board – real-time sync
+
+on:
+  pull_request:
+    types: [review_requested, closed]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  # Trigger a full sync whenever this repo has a relevant event.
+  # The reusable workflow is idempotent: it only adds/updates/archives
+  # items whose state has actually changed.
+  sync:
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'review_requested' &&
+       github.event.requested_team.slug == 'epic-review-team') ||
+      github.event_name == 'pull_request_review' ||
+      (github.event_name == 'pull_request' && github.event.action == 'closed')
+    uses: eic/.github/.github/workflows/sync-epic-review-board.yml@main
+    secrets:
+      EPIC_REVIEW_BOARD_TOKEN: ${{ secrets.EPIC_REVIEW_BOARD_TOKEN }}


### PR DESCRIPTION
## Summary

Adds automation for the **ePIC Review Board** ([project #19](https://github.com/orgs/eic/projects/19)) — a kanban board that tracks pull requests across the eic org that are waiting on a review from `eic/epic-review-team`.

### What was set up with `gh` (already done)

- ✅ Project board created: https://github.com/orgs/eic/projects/19 (public)
- ✅ Columns configured: **Needs Review** → **In Review** → **Changes Requested** → **Approved**
- ✅ Linked repositories: `eic/EICrecon`, `eic/epic`, `eic/containers`, `eic/detector_benchmarks`, `eic/npsim`, `eic/eic-spack`, `eic/spack`, `eic/physics_benchmarks`, `eic/irt`, `eic/perfetto-launcher`

### What this PR adds

**`.github/workflows/sync-epic-review-board.yml`** — a scheduled workflow (every 15 min) that:
1. Searches the eic org for open PRs with a `review-requested:eic/epic-review-team` and adds any not yet on the board
2. Syncs the Status column of every board item to match the PR's current review state
3. Archives items whose PR has been closed or merged

The workflow also exposes a `workflow_call` trigger so individual repos can opt in to **real-time** column updates (see below).

**`workflow-templates/epic-review-board.yml`** — an optional starter workflow for individual repos. When added to a repo, it triggers an immediate sync on `review_requested`, `pull_request_review`, and PR `closed` events instead of waiting up to 15 minutes.

### Required setup (one-time, by an org admin)

Create an org secret named **`EPIC_REVIEW_BOARD_TOKEN`** containing a PAT with scopes:

| Scope | Reason |
|---|---|
| `project` | Read/write project board items |
| `repo` | Search PRs, read PR state |
| `read:org` | Resolve team membership |

Settings → Secrets → Actions → New organization secret → available to `.github` repo (and any other repo using the real-time template).

### Column mapping

| Condition | Column |
|---|---|
| No reviews submitted yet | Needs Review |
| ≥1 review submitted, no decision | In Review |
| `reviewDecision == CHANGES_REQUESTED` | Changes Requested |
| `reviewDecision == APPROVED` | Approved |
| PR closed or merged | Archived (removed from board) |
