### PR TITLE
fix: keep bot-authored PRs in Needs Review column

### DIFF
--- a/.github/workflows/sync-epic-review-board.yml
+++ b/.github/workflows/sync-epic-review-board.yml
@@ -116,6 +116,7 @@ jobs:
                     ... on PullRequest {
                       state
                       reviewDecision
+                      author { __typename }
                       latestReviews(first: 20) { nodes { state author { __typename } } }
                     }
                   }
@@ -123,7 +124,10 @@ jobs:
 
               STATE=$(echo "$DATA"    | jq -r '.data.resource.state')
               DECISION=$(echo "$DATA" | jq -r '.data.resource.reviewDecision // ""')
+              PR_AUTHOR_TYPE=$(echo "$DATA" | jq -r '.data.resource.author.__typename')
               NREVIEWS=$(echo "$DATA" | jq    '[.data.resource.latestReviews.nodes[] | select(.author.__typename == "User")] | length')
+              # A bot-authored PR reviewed only by its controller is not independently reviewed
+              if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then NREVIEWS=0; fi
 
               # Archive PRs that have been closed or merged
               if [ "$STATE" != "OPEN" ]; then


### PR DESCRIPTION
## Problem

PRs submitted by GitHub App / Bot accounts are sometimes reviewed by the human who controls that bot. GitHub allows this (they are different accounts), but such a review should not count as an independent review for the ePIC Review Board.

Previously, any human `COMMENTED` or `APPROVED` review on a bot-authored PR would advance it to the **In Review** column, even though no independent reviewer had actually looked at it.

## Fix

Query the PR author's `__typename` alongside the existing review data. If the PR author is a `Bot`, force `NREVIEWS=0` so the item stays in **Needs Review** until a genuinely independent reviewer engages.

The `reviewDecision`-based columns (**Approved** / **Changes Requested**) are unaffected — those are driven by branch-protection rules, not `NREVIEWS`.

## Changes

``.github/workflows/sync-epic-review-board.yml``
- Add `author { __typename }` to PR-level GraphQL fields
- Extract `PR_AUTHOR_TYPE`; set `NREVIEWS=0` if `Bot`